### PR TITLE
Fix optional dtype handling in encoders

### DIFF
--- a/graph_generation/__init__.py
+++ b/graph_generation/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities for generating graph datasets."""

--- a/graph_generation/graph_dataset_generator.py
+++ b/graph_generation/graph_dataset_generator.py
@@ -7,7 +7,6 @@ import pandas as pd
 import numpy as np
 import torch
 from dotenv import load_dotenv; load_dotenv()
-from kaggle.api.kaggle_api_extended import KaggleApi
 from sentence_transformers import SentenceTransformer
 from torch_geometric.data import HeteroData
 from torch_geometric.transforms import ToUndirected, RandomLinkSplit
@@ -19,7 +18,10 @@ class IdentityEncoder:
         self.dtype = dtype
 
     def __call__(self, values: pd.Series) -> torch.Tensor:
-        return torch.from_numpy(values.to_numpy()).view(-1, 1).to(self.dtype)
+        tensor = torch.from_numpy(values.to_numpy()).view(-1, 1)
+        if self.dtype is not None:
+            tensor = tensor.to(self.dtype)
+        return tensor
 
 
 class ListEncoder:
@@ -28,7 +30,9 @@ class ListEncoder:
         self.dtype = dtype
 
     def __call__(self, values: pd.Series) -> torch.Tensor:
-        return  torch.tensor(values.tolist(), dtype=self.dtype)    
+        if self.dtype is not None:
+            return torch.tensor(values.tolist(), dtype=self.dtype)
+        return torch.tensor(values.tolist())
 
 
 class SequenceEncoder:
@@ -67,9 +71,9 @@ class SequenceListEncoder:
 
 def download_raw_data(dataset_name: str, destination_path: str) -> None:
     """Download raw dataset files from Kaggle."""
+    from kaggle.api.kaggle_api_extended import KaggleApi
     api = KaggleApi()
     # api.authenticate()
-
     api.dataset_download_files(dataset_name, path=destination_path, unzip=True)
 
 

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1,0 +1,25 @@
+import pandas as pd
+import torch
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from graph_generation.graph_dataset_generator import IdentityEncoder, ListEncoder
+
+
+def test_identity_encoder_handles_optional_dtype():
+    s = pd.Series([1, 2, 3])
+    enc = IdentityEncoder()
+    tensor = enc(s)
+    assert tensor.shape == (3, 1)
+    assert tensor.dtype == torch.int64
+
+
+def test_list_encoder_handles_optional_dtype():
+    s = pd.Series([[1, 2], [3, 4]])
+    enc = ListEncoder()
+    tensor = enc(s)
+    assert tensor.shape == (2, 2)
+    assert tensor.dtype == torch.int64


### PR DESCRIPTION
## Summary
- avoid passing `None` as dtype in `IdentityEncoder` and `ListEncoder`
- lazily import Kaggle API to prevent import-time auth errors
- add package init and unit tests for encoders

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f92d0a16083289eeead1dcb6d1e02